### PR TITLE
Fix multihash mismatch

### DIFF
--- a/customer-wallet/package.json
+++ b/customer-wallet/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git",
+    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git#fix-multihash-mismatch",
     "chlu-wallet-support-js": "https://github.com/ChluNetwork/chlu-wallet-support-js.git",
     "classnames": "^2.2.5",
     "js-file-download": "^0.4.1",

--- a/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/index.js
+++ b/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/index.js
@@ -59,9 +59,9 @@ class CustomerWalletFormWrapper extends Component {
 
       const reviewRecord = {
         popr: {
-          item_id: 0,
-          invoice_id: 0,
-          customer_id: 0,
+          item_id: '0',
+          invoice_id: '0',
+          customer_id: '0',
           created_at: 0,
           expires_at: 0,
           currency_symbol: 'USD',

--- a/customer-wallet/yarn.lock
+++ b/customer-wallet/yarn.lock
@@ -1715,9 +1715,9 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git":
+"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git#fix-multihash-mismatch":
   version "0.1.0"
-  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#1f41c044d1932290d9d3dfeb30c42b0745ed269f"
+  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#fbd450515b182250b465af159825f9ead3e1c5a2"
   dependencies:
     bitcoinjs-lib "^3.3.2"
     ipfs "~0.27.7"


### PR DESCRIPTION
PR changes the default item_id and other string fields in PoPR to be strings, also uses a ChluIPFS version from https://github.com/ChluNetwork/chlu-ipfs-support/pull/54 so that the problem with the `last_reviewrecord_multihash` field is solved as well.

Hopefully the mismatched multihash should not happen anymore with new reviews! 