### PR TITLE
[WIP] Marketplace Integration

### DIFF
--- a/customer-wallet/.env.example
+++ b/customer-wallet/.env.example
@@ -7,3 +7,6 @@ REACT_APP_BLOCKCYPHER_TOKEN=xxxx-xxxx-xxxx-xxxx
 REACT_APP_BLOCKCYPHER_RESOURCE=test3
 
 OPEN_EXCHANGE_KEY=xxxx-xxxx-xxxx-xxxx
+
+REACT_APP_MARKETPLACE_URL=http://localhost:4000
+REACT_APP_VENDOR_ID=Qmxxxxxxxxx...

--- a/customer-wallet/package.json
+++ b/customer-wallet/package.json
@@ -40,7 +40,9 @@
     "build": "npm run build-css && react-scripts build",
     "prebuild": "cp webpack.config.prod.js node_modules/react-scripts/config",
     "postbuild": "npx uglify-es build/static/js/main.*.js -o build/static/js/$(ls build/static/js | head -n 1)",
-    "deploy": "node ./deploy.js",
+    "deploy-s3": "npm run delete-source-maps && aws s3 sync build/ s3://demo.chlu.io --delete --exclude index.html --acl public-read && aws s3 sync build/ s3://demo.chlu.io --exclude '*' --include index.html --acl public-read --cache-control 'max-age=0'",
+    "deploy-ipfs": "npm run delete-source-maps && node ./deploy.js",
+    "delete-source-maps": "find ./build -name *.map -type f -delete",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint ."

--- a/customer-wallet/package.json
+++ b/customer-wallet/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
-    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git#popr-crypto",
+    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git#review-updates",
     "chlu-wallet-support-js": "https://github.com/ChluNetwork/chlu-wallet-support-js.git",
     "classnames": "^2.2.5",
     "js-file-download": "^0.4.1",
@@ -28,6 +28,9 @@
     "redux-form": "^7.0.3",
     "redux-thunk": "^2.2.0",
     "superagent": "^3.6.0"
+  },
+  "resolutions": {
+    "node-forge": "0.7.4"
   },
   "scripts": {
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",

--- a/customer-wallet/package.json
+++ b/customer-wallet/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "homepage": ".",
   "dependencies": {
+    "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git",
     "chlu-wallet-support-js": "https://github.com/ChluNetwork/chlu-wallet-support-js.git",

--- a/customer-wallet/package.json
+++ b/customer-wallet/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
-    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git",
+    "chlu-ipfs-support": "https://github.com/ChluNetwork/chlu-ipfs-support.git#popr-crypto",
     "chlu-wallet-support-js": "https://github.com/ChluNetwork/chlu-wallet-support-js.git",
     "classnames": "^2.2.5",
     "js-file-download": "^0.4.1",

--- a/customer-wallet/public/index.html
+++ b/customer-wallet/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Chlu Demo for BTC Testnet</title>
   </head>
   <body>
     <noscript>

--- a/customer-wallet/src/containers/App.js
+++ b/customer-wallet/src/containers/App.js
@@ -9,6 +9,8 @@ import createStore from 'store/createStore'
 import 'styles/main.css'
 
 const store = createStore()
+// Need to keep a ref to window so that chluIpfs can dispatch events
+window.reduxStore = store;
 
 class App extends Component {
   render() {

--- a/customer-wallet/src/containers/Customer/Checkout/index.js
+++ b/customer-wallet/src/containers/Customer/Checkout/index.js
@@ -2,12 +2,14 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 // redux
 import { connect } from 'react-redux'
-import { getCheckout } from 'store/modules/data/checkout'
+import { getCheckout, goToPayment } from 'store/modules/data/checkout'
 // components
 import RaisedButton from 'material-ui/RaisedButton'
 import PaySection from './sections/PaySection'
 import ProductSection from './sections/ProductSection'
 import CircularProgress from 'material-ui/CircularProgress'
+// helpers
+import replace from 'helpers/replace'
 // styles
 import './styles.css'
 import styles from 'styles/inlineStyles/containers/Customer/checkout'
@@ -24,6 +26,7 @@ class Checkout extends Component {
     const {
       checkout: {
         loading,
+        error,
         data: { rating, avatar, price, product }
       }
     } = this.props
@@ -32,21 +35,26 @@ class Checkout extends Component {
       <div className='page-container checkout color-main'>
         <div className='container'>
           {
-            loading
-              ? <CircularProgress />
-              : <div className='checkout-vendor'>
-                  <ProductSection product={product} price={price} avatar={avatar} rating={rating} />
-                  <div className='payment-label'>Payment Method</div>
-                  <PaySection />
-                  <div className='checkout-vendor__button'>
-                    <RaisedButton
-                      {...buttonStyle}
-                      label='Continue'
-                      fullWidth={true}
-                      onClick={() => null}
-                    />
+            error
+              ? error
+              : (
+                loading
+                  ? <CircularProgress />
+                  : <div className='checkout-vendor'>
+                      <ProductSection product={product} price={price} avatar={avatar} rating={rating} />
+                      <div className='payment-label'>Payment Method</div>
+                      <PaySection />
+                      <div className='checkout-vendor__button'>
+                        <RaisedButton
+                          {...buttonStyle}
+                          label='Continue'
+                          fullWidth={true}
+                          onClick={() => replace('/customer/wallet')}
+                        />
+                      </div>
                   </div>
-              </div>
+                )
+            
           }
         </div>
       </div>
@@ -59,7 +67,7 @@ Checkout.propTypes = {
   getCheckout: PropTypes.func.isRequired
 }
 
-const maoStateToProps = store => ({
+const mapStateToProps = store => ({
   checkout: store.data.checkout
 })
 
@@ -67,4 +75,4 @@ const mapDispatchToProps = {
   getCheckout
 }
 
-export default connect(maoStateToProps, mapDispatchToProps)(Checkout)
+export default connect(mapStateToProps, mapDispatchToProps)(Checkout)

--- a/customer-wallet/src/containers/Customer/Checkout/index.js
+++ b/customer-wallet/src/containers/Customer/Checkout/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 // redux
 import { connect } from 'react-redux'
-import { getCheckout, goToPayment } from 'store/modules/data/checkout'
+import { getCheckout } from 'store/modules/data/checkout'
 // components
 import RaisedButton from 'material-ui/RaisedButton'
 import PaySection from './sections/PaySection'

--- a/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/CustomerWalletForm.js
+++ b/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/CustomerWalletForm.js
@@ -7,7 +7,6 @@ import { compose, withHandlers } from 'recompose'
 import { connect } from 'react-redux'
 // helpers
 import { convertToBits } from 'helpers/converters'
-// import { formatCurrency } from 'helpers/currencyFormat'
 // hoc
 import withFxRates from 'containers/Hoc/withFxRates'
 // components
@@ -256,7 +255,7 @@ function validate(values) {
   const requiredFieldError = 'This field is required'
   // Cryptocurrency payment
   if (isEmpty(values.toAddress)) errors.toAddress = requiredFieldError
-  if (isEmpty(values.amountBtc) && isEmpty(values.amountUsd)) {
+  if (isEmpty(String(values.amountBtc)) && isEmpty(String(values.amountUsd))) {
     errors.amountBtc = requiredFieldError
     errors.amountUsd = requiredFieldError
   }
@@ -276,13 +275,13 @@ export default compose(
     validate
   }),
   withFxRates,
-    connect( state => {
-        const { amountBtc, amountUsd } = selector(state, 'amountBtc', 'amountUsd')
-        return {
-            amountBtc,
-            amountUsd
-        }
-    }, mapDispatchToProps),
+  connect( state => {
+      const { amountBtc, amountUsd } = selector(state, 'amountBtc', 'amountUsd')
+      return {
+          amountBtc,
+          amountUsd
+      }
+  }, mapDispatchToProps),
   withHandlers({
     convertFieldValue: ({ getFx, changeField }) => (value, { name, fromTo }) => {
       let convertedValue = getFx().convert(value, fromTo)

--- a/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/index.js
+++ b/customer-wallet/src/containers/Customer/CustomerWallet/CustomerWalletForm/index.js
@@ -106,7 +106,7 @@ class CustomerWalletFormWrapper extends Component {
     const amountBits = convertFromUsdToBits(amountUsd)
 
     if (loading) {
-      return <CircularProgress style={{margin:'auto',display:'block'}}/>
+      return <CircularProgress style={{ margin:'auto',display:'block' }}/>
     }
 
     return (

--- a/customer-wallet/src/fixtures/checkout.js
+++ b/customer-wallet/src/fixtures/checkout.js
@@ -1,6 +1,7 @@
 const checkoutData = {
   avatar: 'https://www.apple-iphone.ru/wp-content/uploads/2014/01/iphone6-2.png',
   product: 'Apple iPhone 6',
+  vendorAddress: 'ms4TpM57RWHnEq5PRFtfJ8bcdiXoUE3tfv',
   rating: 4,
   price: 414.62
 }

--- a/customer-wallet/src/fixtures/links.js
+++ b/customer-wallet/src/fixtures/links.js
@@ -1,6 +1,5 @@
 const linksForCustomer = [
   { label: 'Checkout', href: `/customer/checkout` },
-  { label: 'Customer Wallet', href: `/customer/wallet` },
   { label: 'Transactions', href: `/customer/transactions` },
   { label: 'Settings', href: '/customer/settings' }
 ]

--- a/customer-wallet/src/helpers/ipfs.js
+++ b/customer-wallet/src/helpers/ipfs.js
@@ -1,4 +1,5 @@
 import ChluIPFS from 'chlu-ipfs-support'
+import { updateReviewRecordAction } from 'store/modules/data/reviews'
 
 export async function getChluIPFS(type) {
     const options = { type }
@@ -8,6 +9,15 @@ export async function getChluIPFS(type) {
         }
         window.chluIpfs = new ChluIPFS(options)
         await window.chluIpfs.start()
+        // Turn Review Record updates into redux actions
+        window.chluIpfs.instance.events.on('updated ReviewRecord', (multihash, updatedMultihash, reviewRecord) => {
+          reviewRecord.editable = reviewRecord.orbitDb === window.chluIpfs.getOrbitDBAddress()
+          window.reduxStore.dispatch(updateReviewRecordAction({
+            multihash, 
+            updatedMultihash,
+            reviewRecord
+          }))
+        })
     } else {
         await window.chluIpfs.waitUntilReady()
         if (type) await window.chluIpfs.switchType(options.type)

--- a/customer-wallet/src/helpers/marketplace.js
+++ b/customer-wallet/src/helpers/marketplace.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+export async function requestPopr(url, vendorId, options = {}) {
+  const response = await axios.post(url + '/vendors/' + vendorId + '/popr', {
+    ...options
+  })
+  return response.data
+}

--- a/customer-wallet/src/routes.js
+++ b/customer-wallet/src/routes.js
@@ -33,13 +33,12 @@ function getRoutes (store) {
         component={AppLayout}
         onEnter={(nextState, replace, proceed) => preloadUser(nextState, proceed, store)}
       >
-        <Route path='customer'>
+        <Route path='customer' onEnter={(nextState, replace, proceed) => checkMissingMnemonic(proceed)}>
           <IndexRedirect to='checkout' />
           <Route path='checkout' component={Checkout}/>
           <Route
             path='wallet'
             component={CustomerWallet}
-            onEnter={(nextState, replace, proceed) => checkMissingMnemonic(proceed)}
           />
           <Route path='transactions' component={TransactionHistory} />
           <Route path='transactions/:address' component={RecentTransactions} />

--- a/customer-wallet/src/routes.js
+++ b/customer-wallet/src/routes.js
@@ -34,7 +34,7 @@ function getRoutes (store) {
         onEnter={(nextState, replace, proceed) => preloadUser(nextState, proceed, store)}
       >
         <Route path='customer'>
-          <IndexRedirect to='wallet' />
+          <IndexRedirect to='checkout' />
           <Route path='checkout' component={Checkout}/>
           <Route
             path='wallet'

--- a/customer-wallet/src/store/modules/data/checkout.js
+++ b/customer-wallet/src/store/modules/data/checkout.js
@@ -1,6 +1,5 @@
 import { createAction, handleActions } from 'redux-actions'
 import { requestPopr } from 'helpers/marketplace'
-import { push } from 'react-router-redux'
 // data
 import checkoutData from 'fixtures/checkout'
 
@@ -37,7 +36,8 @@ export function getCheckout () {
       const vendorId = process.env.REACT_APP_VENDOR_ID || 'Qmtest'
       const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
       const popr = await requestPopr(url, vendorId, {
-          amount: 400
+        amount: checkoutData.price * 100,
+        currency_symbol: 'USD cents'
       })
       dispatch(fetchCheckoutDataSuccess(Object.assign({}, popr, checkoutData)))
       return popr

--- a/customer-wallet/src/store/modules/data/checkout.js
+++ b/customer-wallet/src/store/modules/data/checkout.js
@@ -1,4 +1,6 @@
 import { createAction, handleActions } from 'redux-actions'
+import { requestPopr } from 'helpers/marketplace'
+import { push } from 'react-router-redux'
 // data
 import checkoutData from 'fixtures/checkout'
 
@@ -25,21 +27,22 @@ export const fetchCheckoutDataLoading = createAction(FETCH_CHECKOUT_DATA_LOADING
 // ------------------------------------
 // Thunks
 // ------------------------------------
-function testReq () {
-  return new Promise(resolve => setTimeout(() =>
-    resolve(checkoutData), 1000))
-}
 
 export function getCheckout () {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(fetchCheckoutDataLoading(true))
     try {
-      const response = await testReq()
-      dispatch(fetchCheckoutDataSuccess(response))
-      return response
+      // TODO: replace fixture data with stuff from PoPR
+      // TODO: handle error in UI
+      const vendorId = process.env.REACT_APP_VENDOR_ID || 'Qmtest'
+      const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
+      const popr = await requestPopr(url, vendorId, {
+          amount: 400
+      })
+      dispatch(fetchCheckoutDataSuccess(Object.assign({}, popr, checkoutData)))
+      return popr
     } catch (error) {
-      dispatch(fetchCheckoutDataError(error))
-      throw error
+      dispatch(fetchCheckoutDataError(error.message || error))
     }
   }
 }
@@ -54,7 +57,7 @@ export default handleActions({
     loading: false,
     error: null
   }),
-  [FETCH_CHECKOUT_DATA_ERROR]: (state, { payload: { error } }) => ({
+  [FETCH_CHECKOUT_DATA_ERROR]: (state, { payload: error }) => ({
     ...state,
     loading: false,
     error

--- a/customer-wallet/src/store/modules/data/payment.js
+++ b/customer-wallet/src/store/modules/data/payment.js
@@ -49,7 +49,7 @@ export function submitPayment (data) {
         amount: amountSatoshi,
         customer_address: activeAddress,
         vendor_address: toAddress,
-        review_text: review,
+        review_text: review || '', // TODO: fix missing string field encoding different from empty string
         detailed_review: [],
         rating: rating,
         chlu_version: 0
@@ -60,6 +60,7 @@ export function submitPayment (data) {
       console.log(response)
       await tr.pushTransaction(response)
       await chluIpfs.storeReviewRecord(reviewRecord)
+      toastr.success('success', 'Payment success')
       dispatch(setPaymentSuccess())
     } catch(exception) {
       console.log(exception)

--- a/customer-wallet/src/store/modules/data/payment.js
+++ b/customer-wallet/src/store/modules/data/payment.js
@@ -54,11 +54,16 @@ export function submitPayment (data) {
         rating: rating,
         chlu_version: 0
       }
+      console.log('Getting ChluIPFS')
       const chluIpfs = await getChluIPFS(types.customer)
+      console.log('Storing review record (no publish)')
       const multihash = await chluIpfs.storeReviewRecord(reviewRecord, { publish: false })
+      console.log('Creating transaction')
       const response = await tr.create(activeAddress, toAddress, amountSatoshi, null, multihash)
       console.log(response)
+      console.log('Pushing transaction')
       await tr.pushTransaction(response)
+      console.log('Publishing review record')
       await chluIpfs.storeReviewRecord(reviewRecord)
       toastr.success('success', 'Payment success')
       dispatch(setPaymentSuccess())

--- a/customer-wallet/src/store/modules/data/reviews.js
+++ b/customer-wallet/src/store/modules/data/reviews.js
@@ -29,7 +29,7 @@ export const cancelEditReview = createAction(EDIT_REVIEW_CANCEL)
 export const editReviewLoading = createAction(EDIT_REVIEW_LOADING)
 export const editReviewError = createAction(EDIT_REVIEW_ERROR)
 const editReviewSuccess = createAction(EDIT_REVIEW_SUCCESS)
-const updateReviewRecordAction = createAction(UPDATE_REVIEW_RECORD)
+export const updateReviewRecordAction = createAction(UPDATE_REVIEW_RECORD)
 export const readReviewRecordLoading = createAction(READ_REVIEWRECORD_LOADING)
 export const readReviewRecordSuccess = createAction(READ_REVIEWRECORD_SUCCESS)
 export const readReviewRecordError = createAction(READ_REVIEWRECORD_ERROR)
@@ -44,15 +44,7 @@ export function readReviewRecord (type, txHash, multihash) {
     try {
       const chluIpfs = await getChluIPFS(type)
       const reviewRecord = await chluIpfs.readReviewRecord(multihash, {
-        notifyUpdate: async (multihash, newMultihash) => {
-          const rr = await chluIpfs.readReviewRecord(newMultihash)
-          rr.editable = reviewRecord.orbitDb === chluIpfs.getOrbitDBAddress()
-          dispatch(updateReviewRecordAction({
-            multihash, 
-            newMultihash,
-            reviewRecord: rr
-          }))
-        }
+        checkForUpdates: true
       })
       reviewRecord.editable = reviewRecord.orbitDb === chluIpfs.getOrbitDBAddress()
       dispatch(readReviewRecordSuccess({ reviewRecord, multihash, txHash }))

--- a/customer-wallet/yarn.lock
+++ b/customer-wallet/yarn.lock
@@ -401,6 +401,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
@@ -3603,6 +3610,12 @@ flatmap@0.0.3:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+follow-redirects@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1:
   version "1.0.2"

--- a/customer-wallet/yarn.lock
+++ b/customer-wallet/yarn.lock
@@ -1728,15 +1728,15 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git#popr-crypto":
+"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git#review-updates":
   version "0.1.0"
-  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#e85026ef130372e63900827b2e75f6073ce12a2e"
+  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#4ec8c4820412bdfbd88024b5cef94f1b192da9cc"
   dependencies:
     axios "^0.18.0"
     bitcoinjs-lib "^3.3.2"
-    ipfs "~0.27.7"
+    ipfs "~0.28.0"
     lodash "^4.17.5"
-    orbit-db "~0.19.4"
+    orbit-db "~0.19.7"
     protons "~1.0.1"
 
 "chlu-wallet-support-js@https://github.com/ChluNetwork/chlu-wallet-support-js.git":
@@ -1783,7 +1783,7 @@ cids@^0.4.1:
     multicodec "~0.1.7"
     multihashes "~0.4.4"
 
-cids@^0.5.2, cids@~0.5.1, cids@~0.5.2:
+cids@^0.5.2, cids@~0.5.1, cids@~0.5.2, cids@~0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.3.tgz#9a25b697eb76faf807afcec35c4ab936edfbd0a4"
   dependencies:
@@ -1980,7 +1980,7 @@ concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^1.6.0:
+concat-stream@^1.6.0, concat-stream@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
   dependencies:
@@ -2413,6 +2413,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -2711,7 +2715,7 @@ electron-to-chromium@^1.3.30:
 
 elliptic@=3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
+  resolved "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
   dependencies:
     bn.js "^2.0.0"
     brorand "^1.0.1"
@@ -3521,7 +3525,7 @@ file-loader@1.1.5:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-file-type@^7.4.0:
+file-type@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-7.6.0.tgz#b3dbfc8029148e86f30761b21253562943d21f06"
 
@@ -3540,7 +3544,7 @@ filesize@3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
 
-filesize@^3.5.11:
+filesize@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.0.tgz#22d079615624bb6fd3c04026120628a41b3f4efa"
 
@@ -4167,7 +4171,7 @@ hoek@4.x.x, hoek@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoek@5.x.x, hoek@^5.0.2:
+hoek@5.x.x, hoek@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
 
@@ -4316,6 +4320,12 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+human-to-milliseconds@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/human-to-milliseconds/-/human-to-milliseconds-1.0.0.tgz#cc25944810619a010cf13650fed0bd11bb4e14e8"
+  dependencies:
+    promisify-es6 "^1.0.3"
+
 hyperdiff@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hyperdiff/-/hyperdiff-2.0.4.tgz#0f03b10f75bf74d0d5aadf99dbc33aebf743492b"
@@ -4352,9 +4362,13 @@ idb-wrapper@^1.5.0:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/idb-wrapper/-/idb-wrapper-1.7.2.tgz#8251afd5e77fe95568b1c16152eb44b396767ea2"
 
-ieee754@^1.1.4, ieee754@^1.1.8:
+ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+ieee754@^1.1.8:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.10.tgz#719a6f7b026831e64bdb838b0de1bb0029bbf716"
 
 ignore@^3.2.0, ignore@^3.3.3:
   version "3.3.7"
@@ -4539,43 +4553,44 @@ ipaddr.js@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
-ipfs-api@^17.3.0:
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/ipfs-api/-/ipfs-api-17.5.0.tgz#43d3e1876bff5dadf55009b73f6d0b20be814646"
+ipfs-api@^18.1.2:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/ipfs-api/-/ipfs-api-18.2.0.tgz#10b3095509aa4ec121ba1b4a7e29edea4e61281d"
   dependencies:
     async "^2.6.0"
+    big.js "^5.0.3"
     bs58 "^4.0.1"
-    cids "~0.5.2"
-    concat-stream "^1.6.0"
+    cids "~0.5.3"
+    concat-stream "^1.6.1"
     detect-node "^2.0.3"
     flatmap "0.0.3"
     glob "^7.1.2"
     ipfs-block "~0.6.1"
     ipfs-unixfs "~0.1.14"
-    ipld-dag-pb "~0.11.4"
+    ipld-dag-pb "~0.13.1"
     is-ipfs "^0.3.2"
     is-stream "^1.1.0"
-    lru-cache "^4.1.1"
+    lru-cache "^4.1.2"
     multiaddr "^3.0.2"
     multihashes "~0.4.13"
     ndjson "^1.5.0"
     once "^1.4.0"
-    peer-id "~0.10.4"
-    peer-info "~0.11.4"
+    peer-id "~0.10.6"
+    peer-info "~0.11.6"
     promisify-es6 "^1.0.3"
     pull-defer "^0.2.2"
-    pull-pushable "^2.1.2"
-    pump "^2.0.0"
+    pull-pushable "^2.2.0"
+    pump "^3.0.0"
     qs "^6.5.1"
-    readable-stream "^2.3.3"
-    stream-http "^2.7.2"
+    readable-stream "^2.3.5"
+    stream-http "^2.8.1"
     stream-to-pull-stream "^1.7.2"
     streamifier "^0.1.1"
     tar-stream "^1.5.5"
 
-ipfs-bitswap@~0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/ipfs-bitswap/-/ipfs-bitswap-0.18.1.tgz#8efb2a2d34444b2b451e6bb860ac8b2ea5228407"
+ipfs-bitswap@~0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/ipfs-bitswap/-/ipfs-bitswap-0.19.0.tgz#64f5889b28215e7c710154a200736bc5aba80427"
   dependencies:
     async "^2.6.0"
     big.js "^5.0.3"
@@ -4626,9 +4641,9 @@ ipfs-multipart@~0.1.0:
     content "^3.0.0"
     dicer "^0.2.5"
 
-"ipfs-pubsub-room@github:haadcode/ipfs-pubsub-room#orbitdb":
-  version "1.1.3"
-  resolved "https://codeload.github.com/haadcode/ipfs-pubsub-room/tar.gz/68aecffc0c89b2430349d59c2556c0f70b2f96e5"
+ipfs-pubsub-room@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ipfs-pubsub-room/-/ipfs-pubsub-room-1.2.0.tgz#6444573780baf3a78addd67a36f6239090f7db7e"
   dependencies:
     hyperdiff "^2.0.3"
     lodash.clonedeep "^4.5.0"
@@ -4636,7 +4651,7 @@ ipfs-multipart@~0.1.0:
     pull-stream "^3.6.1"
     safe-buffer "^5.1.1"
 
-ipfs-repo@~0.18.2, ipfs-repo@~0.18.5:
+ipfs-repo@~0.18.5, ipfs-repo@~0.18.7:
   version "0.18.7"
   resolved "https://registry.yarnpkg.com/ipfs-repo/-/ipfs-repo-0.18.7.tgz#a25b00d5f03437f313f10085bd181b1182a76502"
   dependencies:
@@ -4659,7 +4674,7 @@ ipfs-repo@~0.18.2, ipfs-repo@~0.18.5:
     multiaddr "^3.0.1"
     pull-stream "^3.6.1"
 
-ipfs-unixfs-engine@~0.24.2:
+ipfs-unixfs-engine@~0.24.4:
   version "0.24.4"
   resolved "https://registry.yarnpkg.com/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.24.4.tgz#96d381b5a81ce74c03feac5c01f6c234a2bf106b"
   dependencies:
@@ -4692,11 +4707,12 @@ ipfs-unixfs@~0.1.14:
   dependencies:
     protons "^1.0.0"
 
-ipfs@~0.27.7:
-  version "0.27.7"
-  resolved "https://registry.yarnpkg.com/ipfs/-/ipfs-0.27.7.tgz#c73ab18888fce2b99437c97bcb656f9d22f95b33"
+ipfs@~0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/ipfs/-/ipfs-0.28.2.tgz#1e9806354fdeecd773ffa612c28953c9a1ac64a0"
   dependencies:
     async "^2.6.0"
+    big.js "^5.0.3"
     binary-querystring "~0.1.2"
     bl "^1.2.1"
     boom "^7.1.1"
@@ -4704,52 +4720,56 @@ ipfs@~0.27.7:
     byteman "^1.3.5"
     cids "~0.5.2"
     debug "^3.1.0"
-    file-type "^7.4.0"
-    filesize "^3.5.11"
+    file-type "^7.6.0"
+    filesize "^3.6.0"
     fsm-event "^2.1.0"
     get-folder-size "^1.0.1"
     glob "^7.1.2"
     hapi "^16.6.2"
     hapi-set-header "^1.0.2"
-    hoek "^5.0.2"
-    ipfs-api "^17.3.0"
-    ipfs-bitswap "~0.18.0"
+    hoek "^5.0.3"
+    human-to-milliseconds "^1.0.0"
+    ipfs-api "^18.1.2"
+    ipfs-bitswap "~0.19.0"
     ipfs-block "~0.6.1"
     ipfs-block-service "~0.13.0"
     ipfs-multipart "~0.1.0"
-    ipfs-repo "~0.18.5"
+    ipfs-repo "~0.18.7"
     ipfs-unixfs "~0.1.14"
-    ipfs-unixfs-engine "~0.24.2"
-    ipld-resolver "~0.14.1"
+    ipfs-unixfs-engine "~0.24.4"
+    ipld "^0.15.0"
     is-ipfs "^0.3.2"
     is-stream "^1.1.0"
-    joi "^13.1.0"
-    libp2p "~0.15.0"
+    joi "^13.1.2"
+    joi-browser "^13.0.1"
+    joi-multiaddr "^1.0.1"
+    libp2p "~0.18.0"
     libp2p-circuit "~0.1.4"
-    libp2p-floodsub "~0.13.1"
-    libp2p-kad-dht "~0.6.0"
-    libp2p-mdns "~0.9.1"
+    libp2p-floodsub "~0.14.1"
+    libp2p-kad-dht "~0.8.0"
+    libp2p-keychain "~0.3.1"
+    libp2p-mdns "~0.9.2"
     libp2p-multiplex "~0.5.1"
     libp2p-railing "~0.7.1"
-    libp2p-secio "~0.9.0"
-    libp2p-tcp "~0.11.2"
-    libp2p-webrtc-star "~0.13.3"
-    libp2p-websocket-star "~0.7.2"
-    libp2p-websockets "~0.10.4"
+    libp2p-secio "~0.9.3"
+    libp2p-tcp "~0.11.6"
+    libp2p-webrtc-star "~0.13.4"
+    libp2p-websocket-star "~0.7.7"
+    libp2p-websockets "~0.10.5"
     lodash.flatmap "^4.5.0"
     lodash.get "^4.4.2"
     lodash.sortby "^4.7.0"
     lodash.values "^4.3.0"
-    mafmt "^3.0.2"
-    mime-types "^2.1.17"
+    mafmt "^4.0.0"
+    mime-types "^2.1.18"
     mkdirp "~0.5.1"
     multiaddr "^3.0.2"
     multihashes "~0.4.13"
     once "^1.4.0"
     path-exists "^3.0.0"
-    peer-book "~0.5.2"
-    peer-id "~0.10.4"
-    peer-info "~0.11.4"
+    peer-book "~0.5.4"
+    peer-id "~0.10.6"
+    peer-info "~0.11.6"
     progress "^2.0.0"
     promisify-es6 "^1.0.3"
     pull-abortable "^4.1.1"
@@ -4757,21 +4777,21 @@ ipfs@~0.27.7:
     pull-file "^1.1.0"
     pull-ndjson "^0.1.1"
     pull-paramap "^1.2.2"
-    pull-pushable "^2.1.2"
+    pull-pushable "^2.2.0"
     pull-sort "^1.0.1"
-    pull-stream "^3.6.1"
+    pull-stream "^3.6.2"
     pull-stream-to-stream "^1.3.4"
     pull-zip "^2.0.1"
     read-pkg-up "^3.0.0"
-    readable-stream "2.3.3"
+    readable-stream "2.3.4"
     safe-buffer "^5.1.1"
     stream-to-pull-stream "^1.7.2"
     tar-stream "^1.5.5"
     temp "~0.8.3"
     through2 "^2.0.3"
     update-notifier "^2.3.0"
-    yargs "^10.1.1"
-    yargs-parser "^8.1.0"
+    yargs "^11.0.0"
+    yargs-parser "^9.0.2"
   optionalDependencies:
     prom-client "^10.2.2"
     prometheus-gc-stats "^0.5.0"
@@ -4786,19 +4806,6 @@ ipld-bitcoin@~0.1.5:
     hash.js "^1.1.3"
     multihashes "~0.4.12"
 
-ipld-dag-cbor@~0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.11.2.tgz#af38d7089d227d0fdca82cab4db9b83e4f60dbb6"
-  dependencies:
-    async "^2.6.0"
-    borc "^2.0.2"
-    bs58 "^4.0.1"
-    cids "~0.5.2"
-    is-circular "^1.0.1"
-    multihashes "~0.4.12"
-    multihashing-async "~0.4.7"
-    traverse "^0.6.6"
-
 ipld-dag-cbor@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.12.0.tgz#aea01be0d72dfc93004cfa537a75f163439906b6"
@@ -4811,23 +4818,6 @@ ipld-dag-cbor@~0.12.0:
     multihashes "~0.4.12"
     multihashing-async "~0.4.7"
     traverse "^0.6.6"
-
-ipld-dag-pb@~0.11.3, ipld-dag-pb@~0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.11.4.tgz#b0fae5681fad5697132e325d6c2ff17b5f0cb6a8"
-  dependencies:
-    async "^2.6.0"
-    bs58 "^4.0.1"
-    buffer-loader "0.0.1"
-    cids "~0.5.2"
-    ipfs-block "~0.6.1"
-    is-ipfs "~0.3.2"
-    multihashes "~0.4.12"
-    multihashing-async "~0.4.7"
-    protons "^1.0.0"
-    pull-stream "^3.6.1"
-    pull-traverse "^1.0.3"
-    stable "^0.1.6"
 
 ipld-dag-pb@~0.13.0, ipld-dag-pb@~0.13.1:
   version "0.13.1"
@@ -4846,21 +4836,6 @@ ipld-dag-pb@~0.13.0, ipld-dag-pb@~0.13.1:
     pull-traverse "^1.0.3"
     stable "^0.1.6"
 
-ipld-ethereum@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/ipld-ethereum/-/ipld-ethereum-1.4.4.tgz#4ee0604a0d44795c2db56b31902e3083b2c0e1bc"
-  dependencies:
-    async "^2.6.0"
-    cids "~0.5.2"
-    ethereumjs-account "^2.0.4"
-    ethereumjs-block "^1.7.0"
-    ethereumjs-tx "^1.3.3"
-    ipfs-block "~0.6.1"
-    merkle-patricia-tree "^2.2.0"
-    multihashes "~0.4.12"
-    multihashing-async "~0.4.7"
-    rlp "^2.0.0"
-
 ipld-ethereum@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ipld-ethereum/-/ipld-ethereum-2.0.0.tgz#f024c201f8ec670f6c18c91cf3d8d39879330acf"
@@ -4877,18 +4852,6 @@ ipld-ethereum@^2.0.0:
     multihashing-async "~0.4.7"
     rlp "^2.0.0"
 
-ipld-git@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ipld-git/-/ipld-git-0.1.1.tgz#fc9292686f7499b9069dadcbdfc7444ec4715873"
-  dependencies:
-    async "^2.6.0"
-    cids "~0.5.2"
-    multicodec "~0.2.5"
-    multihashes "~0.4.12"
-    multihashing-async "~0.4.7"
-    smart-buffer "^4.0.0"
-    traverse "~0.6.6"
-
 ipld-git@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ipld-git/-/ipld-git-0.2.0.tgz#3f8cfb8ede658b182cffbc70a683d9795bfdc716"
@@ -4901,41 +4864,11 @@ ipld-git@~0.2.0:
     smart-buffer "^4.0.0"
     traverse "~0.6.6"
 
-ipld-raw@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/ipld-raw/-/ipld-raw-1.0.7.tgz#60530405069e7676f3cbbd09c84a8a23da674ace"
-  dependencies:
-    cids "~0.5.2"
-
 ipld-raw@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ipld-raw/-/ipld-raw-2.0.0.tgz#fbac777ebed67e6a5de0991a74f488a005b9e812"
   dependencies:
     cids "~0.5.2"
-
-ipld-resolver@~0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/ipld-resolver/-/ipld-resolver-0.14.1.tgz#78812d5a38db3092ec673b79e6836e128358c5d1"
-  dependencies:
-    async "^2.6.0"
-    cids "~0.5.2"
-    interface-datastore "~0.4.1"
-    ipfs-block "~0.6.1"
-    ipfs-block-service "~0.13.0"
-    ipfs-repo "~0.18.2"
-    ipld-dag-cbor "~0.11.2"
-    ipld-dag-pb "~0.11.3"
-    ipld-ethereum "^1.4.4"
-    ipld-git "~0.1.1"
-    ipld-raw "^1.0.7"
-    is-ipfs "~0.3.2"
-    lodash.flatten "^4.4.0"
-    lodash.includes "^4.3.0"
-    memdown "^1.4.1"
-    multihashes "~0.4.12"
-    pull-sort "^1.0.1"
-    pull-stream "^3.6.1"
-    pull-traverse "^1.0.3"
 
 ipld-zcash@~0.1.3:
   version "0.1.3"
@@ -5774,6 +5707,17 @@ jest@20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
+joi-browser@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/joi-browser/-/joi-browser-13.0.1.tgz#06a7b782d94bca6fa0f107138846ea16588b2e7b"
+
+joi-multiaddr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/joi-multiaddr/-/joi-multiaddr-1.0.1.tgz#9392f0b2b85b1110663639c67266342283c1b91c"
+  dependencies:
+    mafmt "^4.0.0"
+    multiaddr "^3.0.2"
+
 joi@10.x.x:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
@@ -5791,7 +5735,7 @@ joi@^11.1.0:
     isemail "3.x.x"
     topo "2.x.x"
 
-joi@^13.1.0:
+joi@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/joi/-/joi-13.1.2.tgz#b2db260323cc7f919fafa51e09e2275bd089a97e"
   dependencies:
@@ -6079,7 +6023,7 @@ level-js@^2.2.4, level-js@~2.2.4:
     typedarray-to-buffer "~1.0.0"
     xtend "~2.1.2"
 
-"level-js@github:timkuijsten/level.js#idbunwrapper":
+level-js@timkuijsten/level.js#idbunwrapper:
   version "2.2.3"
   resolved "https://codeload.github.com/timkuijsten/level.js/tar.gz/18e03adab34c49523be7d3d58fafb0c632f61303"
   dependencies:
@@ -6177,34 +6121,18 @@ libp2p-crypto@^0.12.1, libp2p-crypto@~0.12.0, libp2p-crypto@~0.12.1:
     tweetnacl "^1.0.0"
     webcrypto-shim "github:dignifiedquire/webcrypto-shim#master"
 
-libp2p-crypto@~0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.10.4.tgz#24fd3f5291fdd8055bc33099e5c9b84fefdf8220"
-  dependencies:
-    asn1.js "^5.0.0"
-    async "^2.6.0"
-    browserify-aes "^1.1.1"
-    keypair "^1.0.1"
-    libp2p-crypto-secp256k1 "~0.2.2"
-    multihashing-async "~0.4.7"
-    pem-jwk "^1.5.1"
-    protons "^1.0.0"
-    rsa-pem-to-jwk "^1.1.3"
-    tweetnacl "^1.0.0"
-    webcrypto-shim "github:dignifiedquire/webcrypto-shim#master"
-
-libp2p-floodsub@~0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/libp2p-floodsub/-/libp2p-floodsub-0.13.1.tgz#b396f1a401130ecf03899c04c95eef92eaa47fab"
+libp2p-floodsub@^0.14.1, libp2p-floodsub@~0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/libp2p-floodsub/-/libp2p-floodsub-0.14.1.tgz#5aa77718c09427123869f53722ad1ae102a3be2e"
   dependencies:
     async "^2.6.0"
     bs58 "^4.0.1"
     debug "^3.1.0"
     length-prefixed-stream "^1.5.1"
-    libp2p-crypto "~0.10.4"
+    libp2p-crypto "~0.12.1"
     lodash.values "^4.3.0"
-    protons "^1.0.0"
-    pull-pushable "^2.1.1"
+    protons "^1.0.1"
+    pull-pushable "^2.1.2"
     time-cache "~0.3.0"
 
 libp2p-identify@~0.6.3:
@@ -6218,9 +6146,9 @@ libp2p-identify@~0.6.3:
     pull-length-prefixed "^1.3.0"
     pull-stream "^3.6.1"
 
-libp2p-kad-dht@~0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/libp2p-kad-dht/-/libp2p-kad-dht-0.6.3.tgz#9409e0454bf0cf3fde7adddcb93e771ba31dcc49"
+libp2p-kad-dht@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/libp2p-kad-dht/-/libp2p-kad-dht-0.8.0.tgz#8d03c566e433c84024399818e49acc6b6871d0cb"
   dependencies:
     async "^2.6.0"
     base32.js "^0.1.0"
@@ -6243,7 +6171,18 @@ libp2p-kad-dht@~0.6.0:
     varint "^5.0.0"
     xor-distance "^1.0.0"
 
-libp2p-mdns@~0.9.1:
+libp2p-keychain@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/libp2p-keychain/-/libp2p-keychain-0.3.1.tgz#de39c8f66161bc82441e6d314f334882f0e249be"
+  dependencies:
+    async "^2.6.0"
+    deepmerge "^1.5.2"
+    interface-datastore "~0.4.2"
+    libp2p-crypto "~0.12.0"
+    pull-stream "^3.6.1"
+    sanitize-filename "^1.6.1"
+
+libp2p-mdns@~0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/libp2p-mdns/-/libp2p-mdns-0.9.2.tgz#16236036f248bdef1716eb8416215013b1d3b81f"
   dependencies:
@@ -6265,7 +6204,7 @@ libp2p-multiplex@~0.5.1:
     pump "^2.0.0"
     stream-to-pull-stream "^1.7.2"
 
-libp2p-ping@~0.6.0:
+libp2p-ping@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/libp2p-ping/-/libp2p-ping-0.6.1.tgz#6f68e02685e975c5a9cfc1322c80a01ff3476584"
   dependencies:
@@ -6296,7 +6235,7 @@ libp2p-record@~0.5.1:
     peer-id "~0.10.0"
     protons "^1.0.0"
 
-libp2p-secio@~0.9.0:
+libp2p-secio@~0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/libp2p-secio/-/libp2p-secio-0.9.3.tgz#21358ded9d6da82dbc3336ba9b2df9a0872f46cf"
   dependencies:
@@ -6313,9 +6252,9 @@ libp2p-secio@~0.9.0:
     pull-length-prefixed "^1.3.0"
     pull-stream "^3.6.2"
 
-libp2p-swarm@~0.35.1:
-  version "0.35.1"
-  resolved "https://registry.yarnpkg.com/libp2p-swarm/-/libp2p-swarm-0.35.1.tgz#fedbf7a80c8650ff06c6321a14dae6d8d2000a4b"
+libp2p-switch@~0.36.1:
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/libp2p-switch/-/libp2p-switch-0.36.1.tgz#65e8ecbac86a7661b08520dd112aa7763f7147bc"
   dependencies:
     async "^2.6.0"
     debug "^3.1.0"
@@ -6327,11 +6266,11 @@ libp2p-swarm@~0.35.1:
     multiaddr "^3.0.2"
     multistream-select "~0.14.1"
     once "^1.4.0"
-    peer-id "~0.10.5"
+    peer-id "~0.10.6"
     peer-info "~0.11.6"
     pull-stream "^3.6.1"
 
-libp2p-tcp@~0.11.2:
+libp2p-tcp@~0.11.2, libp2p-tcp@~0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/libp2p-tcp/-/libp2p-tcp-0.11.6.tgz#e5f33b12a50f3b4c1e9b9ed54be4a59a40de0d9e"
   dependencies:
@@ -6345,7 +6284,7 @@ libp2p-tcp@~0.11.2:
     once "^1.4.0"
     stream-to-pull-stream "^1.7.2"
 
-libp2p-webrtc-star@~0.13.3:
+libp2p-webrtc-star@~0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/libp2p-webrtc-star/-/libp2p-webrtc-star-0.13.4.tgz#31a0ef83203897042db495a914f7b6dfc0c40472"
   dependencies:
@@ -6369,7 +6308,7 @@ libp2p-webrtc-star@~0.13.3:
     stream-to-pull-stream "^1.7.2"
     webrtcsupport "github:ipfs/webrtcsupport"
 
-libp2p-websocket-star@~0.7.2:
+libp2p-websocket-star@~0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/libp2p-websocket-star/-/libp2p-websocket-star-0.7.7.tgz#db04fd85a4057f646aed1bb12b142546976e6aa2"
   dependencies:
@@ -6389,7 +6328,7 @@ libp2p-websocket-star@~0.7.2:
     socket.io-pull-stream "^0.1.4"
     uuid "^3.2.1"
 
-libp2p-websockets@~0.10.4:
+libp2p-websockets@~0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/libp2p-websockets/-/libp2p-websockets-0.10.5.tgz#b2e03207a219b040db4c07f9473fe2367f0381f4"
   dependencies:
@@ -6398,17 +6337,18 @@ libp2p-websockets@~0.10.4:
     mafmt "^4.0.0"
     pull-ws "^3.3.0"
 
-libp2p@~0.15.0:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.15.2.tgz#a5aad2238cf6be8f127b173a34ad6a286b6b36a1"
+libp2p@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.18.0.tgz#481efff6fd35c0f720d2b80a8f8934a03554cb95"
   dependencies:
     async "^2.6.0"
-    libp2p-ping "~0.6.0"
-    libp2p-swarm "~0.35.1"
-    mafmt "^3.0.2"
+    libp2p-floodsub "^0.14.1"
+    libp2p-ping "~0.6.1"
+    libp2p-switch "~0.36.1"
+    mafmt "^4.0.0"
     multiaddr "^3.0.2"
     peer-book "~0.5.4"
-    peer-id "~0.10.5"
+    peer-id "~0.10.6"
     peer-info "~0.11.6"
 
 load-json-file@^1.0.0:
@@ -6782,7 +6722,7 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.1:
+lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
   dependencies:
@@ -6796,12 +6736,6 @@ ltgt@^2.1.2, ltgt@~2.2.0:
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
-
-mafmt@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-3.0.2.tgz#f13aafb6b1cae21fe5593423c1c5398815d4621a"
-  dependencies:
-    multiaddr "^3.0.1"
 
 mafmt@^4.0.0:
   version "4.0.0"
@@ -6973,7 +6907,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@^2.1.17, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -7139,7 +7073,7 @@ multihashing-async@~0.4.6, multihashing-async@~0.4.7, multihashing-async@~0.4.8:
     murmurhash3js "^3.0.1"
     nodeify "^1.0.1"
 
-"multiplex@github:dignifiedquire/multiplex":
+multiplex@dignifiedquire/multiplex:
   version "6.7.0"
   resolved "https://codeload.github.com/dignifiedquire/multiplex/tar.gz/b5d5edd30454e2c978ee8c52df86f5f4840d2eab"
   dependencies:
@@ -7176,7 +7110,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0, nan@^2.0.5, nan@^2.2.1, nan@^2.3.0, nan@^2.6.2:
+nan@^2.0, nan@^2.0.5, nan@^2.2.1, nan@^2.6.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nan@^2.3.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 
@@ -7251,11 +7189,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.6.33:
-  version "0.6.33"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.33.tgz#463811879f573d45155ad6a9f43dc296e8e85ebc"
-
-node-forge@^0.7.1:
+node-forge@0.6.33, node-forge@0.7.4, node-forge@^0.7.1:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.4.tgz#8e6e9f563a1e32213aa7508cded22aa791dbf986"
 
@@ -7666,11 +7600,11 @@ orbit-db-kvstore@~1.2.0:
   dependencies:
     orbit-db-store "~2.2.0"
 
-orbit-db-pubsub@~0.3.8:
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/orbit-db-pubsub/-/orbit-db-pubsub-0.3.9.tgz#d6fc33387651add54288c4f3db661fd7bb6c9231"
+orbit-db-pubsub@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/orbit-db-pubsub/-/orbit-db-pubsub-0.4.0.tgz#32dd4e865b7bbd0349d202c05c3292c7dee8fc12"
   dependencies:
-    ipfs-pubsub-room "github:haadcode/ipfs-pubsub-room#orbitdb"
+    ipfs-pubsub-room "~1.2.0"
     logplease "~1.2.14"
 
 orbit-db-store@~2.2.0:
@@ -7682,9 +7616,9 @@ orbit-db-store@~2.2.0:
     p-each-series "^1.0.0"
     readable-stream "~2.3.3"
 
-orbit-db@~0.19.4:
-  version "0.19.5"
-  resolved "https://registry.yarnpkg.com/orbit-db/-/orbit-db-0.19.5.tgz#e5c1f0636bba3ef8da9fa3059115478c00bc250c"
+orbit-db@~0.19.7:
+  version "0.19.7"
+  resolved "https://registry.yarnpkg.com/orbit-db/-/orbit-db-0.19.7.tgz#ff2bfe4bcf74e6bc0fdbcb1c91aa451d90e58dcf"
   dependencies:
     logplease "^1.2.14"
     multihashes "^0.4.12"
@@ -7695,7 +7629,7 @@ orbit-db@~0.19.4:
     orbit-db-feedstore "~1.2.0"
     orbit-db-keystore "~0.1.0"
     orbit-db-kvstore "~1.2.0"
-    orbit-db-pubsub "~0.3.8"
+    orbit-db-pubsub "~0.4.0"
 
 original@>=0.0.5:
   version "1.0.0"
@@ -7949,7 +7883,7 @@ pbkdf2@^3.0.3, pbkdf2@^3.0.9:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-peer-book@~0.5.2, peer-book@~0.5.4:
+peer-book@~0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/peer-book/-/peer-book-0.5.4.tgz#d3d8fe2507aa08306acb328be81f973a8785e704"
   dependencies:
@@ -7957,7 +7891,7 @@ peer-book@~0.5.2, peer-book@~0.5.4:
     peer-id "^0.10.5"
     peer-info "^0.11.6"
 
-peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.10.1, peer-id@~0.10.4, peer-id@~0.10.5, peer-id@~0.10.6:
+peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.10.1, peer-id@~0.10.5, peer-id@~0.10.6:
   version "0.10.6"
   resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.10.6.tgz#cb552e35d2625cf3e4aeb4de45ddb3ee96bb3e8b"
   dependencies:
@@ -7966,7 +7900,7 @@ peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.10.1, peer-id@~0.1
     lodash "^4.17.5"
     multihashes "~0.4.13"
 
-peer-info@^0.11.6, peer-info@~0.11.0, peer-info@~0.11.4, peer-info@~0.11.6:
+peer-info@^0.11.6, peer-info@~0.11.0, peer-info@~0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.11.6.tgz#0480b0030d2df8fd4f09879b269a715b2bd2ba12"
   dependencies:
@@ -8682,6 +8616,13 @@ pump@^2.0.0, pump@^2.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -9029,19 +8970,19 @@ readable-stream@1.1.x, readable-stream@^1.0.33:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@2.3.3, readable-stream@^2.0.1, readable-stream@^2.2.9:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+readable-stream@2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.4, readable-stream@~2.3.3:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.4, readable-stream@^2.3.5, readable-stream@~2.3.3:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
@@ -9049,6 +8990,18 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.1, readable-stream@^2.2.9:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
@@ -9507,6 +9460,12 @@ sane@~1.6.0:
     minimist "^1.1.1"
     walker "~1.0.5"
     watch "~0.10.0"
+
+sanitize-filename@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
 
 sass-graph@^2.1.1, sass-graph@^2.2.4:
   version "2.2.4"
@@ -9986,7 +9945,7 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
-stream-http@^2.7.2:
+stream-http@^2.7.2, stream-http@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.1.tgz#d0441be1a457a73a733a8a7b53570bebd9ef66a4"
   dependencies:
@@ -10450,6 +10409,12 @@ trim-right@^1.0.1:
   dependencies:
     glob "^6.0.4"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -10664,6 +10629,10 @@ user-home@^2.0.0:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
   dependencies:
     os-homedir "^1.0.0"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -11112,15 +11081,15 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   dependencies:
     camelcase "^4.1.0"
 
-yargs@^10.1.1:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.1.1"
@@ -11133,7 +11102,7 @@ yargs@^10.1.1:
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^8.1.0"
+    yargs-parser "^9.0.2"
 
 yargs@^6.6.0:
   version "6.6.0"

--- a/customer-wallet/yarn.lock
+++ b/customer-wallet/yarn.lock
@@ -46,10 +46,10 @@ accept@^2.1.4:
     hoek "4.x.x"
 
 accepts@~1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
-    mime-types "~2.1.16"
+    mime-types "~2.1.18"
     negotiator "0.6.1"
 
 acorn-dynamic-import@^2.0.0:
@@ -173,9 +173,15 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -1095,7 +1101,7 @@ base-x@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.0.tgz#77b56f0311070b780b3c8a5f534beac47e506702"
 
-base-x@^3.0.2:
+base-x@3.0.4, base-x@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
   dependencies:
@@ -1304,8 +1310,8 @@ boom@5.x.x, boom@^5.2.0:
     hoek "4.x.x"
 
 boom@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-7.1.1.tgz#50392a4e3417e971f1ad28622c20e832275260bb"
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-7.2.0.tgz#2bff24a55565767fde869ec808317eb10c48e966"
   dependencies:
     hoek "5.x.x"
 
@@ -1686,12 +1692,12 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
     supports-color "^4.0.0"
 
 chalk@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
-    ansi-styles "^3.2.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^5.2.0"
+    supports-color "^5.3.0"
 
 change-emitter@^0.1.2:
   version "0.1.6"
@@ -1722,15 +1728,14 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git":
+"chlu-ipfs-support@https://github.com/ChluNetwork/chlu-ipfs-support.git#popr-crypto":
   version "0.1.0"
-  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#8b3aa4f9b41c5a9d16254783f938b018021d34ea"
+  resolved "https://github.com/ChluNetwork/chlu-ipfs-support.git#e85026ef130372e63900827b2e75f6073ce12a2e"
   dependencies:
+    axios "^0.18.0"
     bitcoinjs-lib "^3.3.2"
     ipfs "~0.27.7"
-    ipfs-pubsub-room "~1.1.5"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
+    lodash "^4.17.5"
     orbit-db "~0.19.4"
     protons "~1.0.1"
 
@@ -1779,12 +1784,12 @@ cids@^0.4.1:
     multihashes "~0.4.4"
 
 cids@^0.5.2, cids@~0.5.1, cids@~0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.2.tgz#c1baf306f8165baaabfb5134b5c20a50450548a6"
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.3.tgz#9a25b697eb76faf807afcec35c4ab936edfbd0a4"
   dependencies:
-    multibase "~0.3.4"
-    multicodec "~0.2.3"
-    multihashes "~0.4.9"
+    multibase "~0.4.0"
+    multicodec "~0.2.6"
+    multihashes "~0.4.13"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -1926,8 +1931,8 @@ commander@2.12.x, commander@^2.9.0, commander@~2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 commander@^2.11.0, commander@^2.9:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1967,9 +1972,17 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2, concat-stream@^1.6.0:
+concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
@@ -2035,8 +2048,8 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 content@3.x.x, content@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/content/-/content-3.0.6.tgz#9c2e301e9ae515ed65a4b877d78aa5659bb1b809"
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/content/-/content-3.0.7.tgz#0cbb88e82702d35ccf59800b8add609bb5c1dfc2"
   dependencies:
     boom "5.x.x"
 
@@ -2657,8 +2670,8 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 duplexify@^3.4.2:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.3.tgz#8b5818800df92fd0125b27ab896491912858243e"
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.4.tgz#4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4"
   dependencies:
     end-of-stream "^1.0.0"
     inherits "^2.0.1"
@@ -2742,8 +2755,8 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
     once "^1.4.0"
 
 engine.io-client@~3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.5.tgz#85de17666560327ef1817978f6e3f8101ded2c47"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.6.tgz#5bdeb130f8b94a50ac5cbeb72583e7a4a063ddfd"
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
@@ -3221,8 +3234,8 @@ ethereumjs-block@^1.7.0:
     merkle-patricia-tree "^2.1.2"
 
 ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz#ece051d3efdbe771ad2a518d61632ca2ab75ecbb"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz#c2304912f6c07af03237ad8675ac036e290dad48"
   dependencies:
     ethereum-common "^0.0.18"
     ethereumjs-util "^5.0.0"
@@ -3980,8 +3993,8 @@ hapi-set-header@^1.0.2:
   resolved "https://registry.yarnpkg.com/hapi-set-header/-/hapi-set-header-1.0.2.tgz#2afae002c6719d6d54f3fa88462f822892d2df13"
 
 hapi@^16.6.2:
-  version "16.6.2"
-  resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.6.2.tgz#690554fc9c5ca7ad2f8030bbfe21d5e5886cdc14"
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.6.3.tgz#ca9ae1d028afb64d98ac07a1219a1b5eff14d01a"
   dependencies:
     accept "^2.1.4"
     ammo "^2.0.4"
@@ -4180,8 +4193,8 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -4616,16 +4629,6 @@ ipfs-multipart@~0.1.0:
 "ipfs-pubsub-room@github:haadcode/ipfs-pubsub-room#orbitdb":
   version "1.1.3"
   resolved "https://codeload.github.com/haadcode/ipfs-pubsub-room/tar.gz/68aecffc0c89b2430349d59c2556c0f70b2f96e5"
-  dependencies:
-    hyperdiff "^2.0.3"
-    lodash.clonedeep "^4.5.0"
-    pull-pushable "^2.1.1"
-    pull-stream "^3.6.1"
-    safe-buffer "^5.1.1"
-
-ipfs-pubsub-room@~1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ipfs-pubsub-room/-/ipfs-pubsub-room-1.1.5.tgz#7a05069ee9f7ea35349824e450c5e1cf64d44fa5"
   dependencies:
     hyperdiff "^2.0.3"
     lodash.clonedeep "^4.5.0"
@@ -6076,7 +6079,7 @@ level-js@^2.2.4, level-js@~2.2.4:
     typedarray-to-buffer "~1.0.0"
     xtend "~2.1.2"
 
-level-js@timkuijsten/level.js#idbunwrapper:
+"level-js@github:timkuijsten/level.js#idbunwrapper":
   version "2.2.3"
   resolved "https://codeload.github.com/timkuijsten/level.js/tar.gz/18e03adab34c49523be7d3d58fafb0c632f61303"
   dependencies:
@@ -6126,23 +6129,23 @@ levn@^0.3.0, levn@~0.3.0:
     type-check "~0.3.2"
 
 libp2p-circuit@~0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/libp2p-circuit/-/libp2p-circuit-0.1.4.tgz#d2210d0dddd5570f7d6c3ed46bdd46ebc31eaba5"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/libp2p-circuit/-/libp2p-circuit-0.1.5.tgz#2553d4d692ee84e882c1c8af2ca3d99c3e3b2133"
   dependencies:
     assert "^1.4.1"
-    async "^2.5.0"
+    async "^2.6.0"
     debug "^3.1.0"
     interface-connection "^0.3.2"
-    lodash "^4.17.4"
-    mafmt "^3.0.2"
-    multiaddr "^3.0.1"
-    multistream-select "^0.14.0"
-    peer-id "^0.10.2"
-    peer-info "^0.11.0"
-    protons "^1.0.0"
+    lodash "^4.17.5"
+    mafmt "^4.0.0"
+    multiaddr "^3.0.2"
+    multistream-select "^0.14.1"
+    peer-id "^0.10.6"
+    peer-info "^0.11.6"
+    protons "^1.0.1"
     pull-abortable "^4.1.1"
     pull-handshake "^1.1.4"
-    pull-stream "^3.6.1"
+    pull-stream "^3.6.2"
     safe-buffer "^5.1.1"
     setimmediate "^1.0.5"
 
@@ -6589,10 +6592,6 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-
 lodash.isequalwith@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
@@ -6784,8 +6783,8 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
 lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -6921,8 +6920,8 @@ merkle-lib@^2.0.10:
   resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
 
 merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-2.3.0.tgz#84c606232ef343f1b96fc972e697708754f08573"
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz#7d4e7263a9c85c1679187cad4a6d71f48d524c71"
   dependencies:
     async "^1.4.2"
     ethereumjs-util "^5.0.0"
@@ -6974,7 +6973,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@^2.1.17, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@^2.1.17, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -7080,6 +7079,12 @@ multibase@~0.3.4:
   dependencies:
     base-x "3.0.0"
 
+multibase@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.4.0.tgz#1bdb62c82de0114f822a1d8751bcbee91cd2efba"
+  dependencies:
+    base-x "3.0.4"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -7104,7 +7109,7 @@ multicodec@~0.1.7:
   dependencies:
     varint "^5.0.0"
 
-multicodec@~0.2.3, multicodec@~0.2.5, multicodec@~0.2.6:
+multicodec@~0.2.5, multicodec@~0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.2.6.tgz#9d2d6565fbc0815b139dfc906371fc39df4dfddb"
   dependencies:
@@ -7134,7 +7139,7 @@ multihashing-async@~0.4.6, multihashing-async@~0.4.7, multihashing-async@~0.4.8:
     murmurhash3js "^3.0.1"
     nodeify "^1.0.1"
 
-multiplex@dignifiedquire/multiplex:
+"multiplex@github:dignifiedquire/multiplex":
   version "6.7.0"
   resolved "https://codeload.github.com/dignifiedquire/multiplex/tar.gz/b5d5edd30454e2c978ee8c52df86f5f4840d2eab"
   dependencies:
@@ -7143,7 +7148,7 @@ multiplex@dignifiedquire/multiplex:
     readable-stream "^2.0.2"
     varint "^4.0.0"
 
-multistream-select@^0.14.0, multistream-select@~0.14.1:
+multistream-select@^0.14.1, multistream-select@~0.14.1:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/multistream-select/-/multistream-select-0.14.1.tgz#32c0d98a277f9b369c292a71360d8a1493c8ee79"
   dependencies:
@@ -7251,8 +7256,8 @@ node-forge@0.6.33:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.33.tgz#463811879f573d45155ad6a9f43dc296e8e85ebc"
 
 node-forge@^0.7.1:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.2.tgz#3703b27f61a4c7613f046377643038b99e6a7891"
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.4.tgz#8e6e9f563a1e32213aa7508cded22aa791dbf986"
 
 node-gyp@^3.3.1:
   version "3.6.2"
@@ -7952,7 +7957,7 @@ peer-book@~0.5.2, peer-book@~0.5.4:
     peer-id "^0.10.5"
     peer-info "^0.11.6"
 
-peer-id@^0.10.2, peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.10.1, peer-id@~0.10.4, peer-id@~0.10.5, peer-id@~0.10.6:
+peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.10.1, peer-id@~0.10.4, peer-id@~0.10.5, peer-id@~0.10.6:
   version "0.10.6"
   resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.10.6.tgz#cb552e35d2625cf3e4aeb4de45ddb3ee96bb3e8b"
   dependencies:
@@ -7961,7 +7966,7 @@ peer-id@^0.10.2, peer-id@^0.10.5, peer-id@^0.10.6, peer-id@~0.10.0, peer-id@~0.1
     lodash "^4.17.5"
     multihashes "~0.4.13"
 
-peer-info@^0.11.0, peer-info@^0.11.6, peer-info@~0.11.0, peer-info@~0.11.4, peer-info@~0.11.6:
+peer-info@^0.11.6, peer-info@~0.11.0, peer-info@~0.11.4, peer-info@~0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.11.6.tgz#0480b0030d2df8fd4f09879b269a715b2bd2ba12"
   dependencies:
@@ -8431,8 +8436,8 @@ prom-client@^10.0.0, prom-client@^10.2.2:
     tdigest "^0.1.1"
 
 prometheus-gc-stats@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/prometheus-gc-stats/-/prometheus-gc-stats-0.5.0.tgz#dce41ab205f1d7909f9ea605d85618126404a789"
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/prometheus-gc-stats/-/prometheus-gc-stats-0.5.1.tgz#4713bc5e9f739ee09a86c964014dfbce4fd50003"
   dependencies:
     optional "^0.1.3"
   optionalDependencies:
@@ -8780,8 +8785,8 @@ raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -9037,8 +9042,8 @@ readable-stream@2.3.3, readable-stream@^2.0.1, readable-stream@^2.2.9:
     util-deprecate "~1.0.1"
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.4, readable-stream@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -9790,12 +9795,12 @@ socket.io-parser@~3.1.1:
     isarray "2.0.1"
 
 socket.io-pull-stream@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/socket.io-pull-stream/-/socket.io-pull-stream-0.1.4.tgz#a56123e185fcfbea9f2cdf2f67161058c4653d4c"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/socket.io-pull-stream/-/socket.io-pull-stream-0.1.5.tgz#4e5d282b93635d8bf7780da405d82fc149346710"
   dependencies:
     data-queue "0.0.3"
     debug "^3.1.0"
-    pull-stream "^3.6.1"
+    pull-stream "^3.6.2"
     uuid "^3.2.1"
 
 socket.io@^2.0.4:
@@ -9926,8 +9931,8 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -9982,8 +9987,8 @@ stream-combiner@~0.0.4:
     duplexer "~0.1.1"
 
 stream-http@^2.7.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.0.tgz#fd86546dac9b1c91aff8fc5d287b98fafb41bc10"
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.1.tgz#d0441be1a457a73a733a8a7b53570bebd9ef66a4"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -10160,9 +10165,9 @@ supports-color@^5.1.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
__State__: this PR is fully working but items without a checkmark have not been done yet

This PR changes the demo so that instead of making up PoPRs it actually calls a REST Endpoint to get a signed one from a real marketplace and vendor (thanks to a running instance of [chlu-marketplace-js](https://github.com/ChluNetwork/chlu-marketplace-js)). It also upgrades to the latest chlu-ipfs with all the cryptography validation implemented, review record signature, etc.

- [x] call marketplace to get a PoPR at the checkout
  - [x] marketplace URL configurable in `.env`
- [x] `/customer/wallet`, the payment screen, can only be accessed through the checkout
- [x] payment screen prefilled with PoPR data
- [ ] payment screen does not allow user to edit the form (except for the review)
- [x] payment screen correctly shows loading status
- [ ] payment screen correctly shows errors
- [ ] checkout screen correctly shows loading status
- [ ] checkout screen correctly shows errors
- [ ] PoPR data is shown in checkout
- [ ] PoPR validity is checked in review record and shown in UI (requires changes to chlu-ipfs)
- [ ] vendor can register with marketplace through UI

### node-forge issue

A package named node-forge has been introduced by updating IPFS which in turn updated libp2p-crypto which uses node-forge 0.7. However, the webpack-dev-server bundled with react-scripts uses a package called selfsigned, but an old version of it which requires node-forge 0.6. This is only used by webpack dev server to self sign certificates (we don't care about that) but yarn resolves node-forge to 0.6 and that's what ends up being bundled in webpack, causing libp2p-crypto to crash.

I edited package.json to force yarn to use node-forge 0.7

### How to set it up

- `.env` needs to be updated with these environment variables:
```
REACT_APP_MARKETPLACE_URL=http://localhost:4000
REACT_APP_VENDOR_ID=QmVs5a6DfVBoxWRm1ZBSWnsiKVgZMR7KXQjBjpA7BtDLJ
```
- follow instructions in the [experimental chlu-marketplace README](https://github.com/ChluNetwork/chlu-marketplace-js/blob/first-implementation/README.md) to set it up with the config file. It's better to use port 4000 so it does not conflict with the react dev server
- run `node src/bin setup-vendor -u http://localhost:4000` in `chlu-marketplace-js` to generate a vendor and set it up on the marketplace. The `WIF` that is printed out can be saved to use the private key in the future. The script will register the vendor and sign the `Pvm` key so that PoPRs can be released, the main point of this is to have a vendor set up for using the demo
- check that vendor is there `curl localhost:4000/vendors` should give you a json list with one multihash (the vendor id). Put this into the `REACT_APP_VENDOR_ID` variable in the demo. If you fetch this on IPFS you will get the raw buffer of the public key of this vendor. Using `curl localhost:4000/vendors/(multihash here)` we can get all the public key multihashes and the signatures required for validating Reviews for this vendor
- The setup is done and the demo should be able to get PoPRs now
- __Important note__: the Demo will request that the RR be pinned while publishing it. Any remote service node won't be able to do so, because the marketplace at `http://localhost:4000` won't be reachable outside the local host and the marketplace key will not be verifiable. We need to either not require the key to be fetched from `http://marketplace/.well-known` every time a RR validation is performed or we need to host a public marketplace somewhere.